### PR TITLE
Dump iOS only IPA with argument --ignore-ios-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # appdecrypt
 
-Decrypt application encrypted binaries on macOS when SIP-enabled (macOS 11.3 or below).
+Decrypt application encrypted binaries on macOS when SIP-disabled (macOS 11.2.3 or below).
 
 This works well and compiles for iOS nicely, if you want use it at iOS devices, you can use build-ios.sh (Thanks @dlevi309).
 
@@ -20,7 +20,7 @@ appdecrypt is a tool to make decrypt application encrypted binaries on macOS whe
 
 Examples:
     mac:
-        appdecrypt /Applicaiton/Test.app /Users/admin/Desktop/Test.app
+        appdecrypt /Application/Test.app /Users/admin/Desktop/Test.app
     iPhone:
         appdecrypt /var/containers/Bundle/Application/XXXXXX /tmp
 
@@ -32,6 +32,7 @@ ARGUMENTS:
 
 OPTIONS:
   -h, --help              Show help information.
+  --ignore-ios-check      Decrypt the app even if M1 can't run it.
 ```
 
 #### For Example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # appdecrypt
-
-Decrypt application encrypted binaries on macOS when SIP-enabled (macOS 11.2.3 or below).
+Decrypt application's encrypted binaries on macOS when SIP-enabled (macOS 11.2.3 or below). *Even if it can decrypt all applications, some iOS apps won't be possible to run on the mac, even after decryption.*
 
 This works well and compiles for iOS nicely, if you want use it at iOS devices, you can use build-ios.sh (Thanks @dlevi309).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # appdecrypt
 
-Decrypt application encrypted binaries on macOS when SIP-disabled (macOS 11.2.3 or below).
+Decrypt application encrypted binaries on macOS when SIP-enabled (macOS 11.2.3 or below).
 
 This works well and compiles for iOS nicely, if you want use it at iOS devices, you can use build-ios.sh (Thanks @dlevi309).
 

--- a/Sources/appdecrypt/ConsoleIO.swift
+++ b/Sources/appdecrypt/ConsoleIO.swift
@@ -34,7 +34,7 @@ class ConsoleIO {
         
         Examples:
             mac:
-                appdecrypt /Applicaiton/Test.app /Users/admin/Desktop/Test.app
+                appdecrypt /Application/Test.app /Users/admin/Desktop/Test.app
             iPhone:
                 appdecrypt /var/containers/Bundle/Application/XXXXXX /tmp
         
@@ -46,7 +46,7 @@ class ConsoleIO {
         
         OPTIONS:
           -h, --help              Show help information.
-          --ignore-ios-check      Decrypt the app anyway, even if M1 can't run it.
+          --ignore-ios-check      Decrypt the app even if M1 can't run it.
         """)
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: NSNotification.Name("stop"), object: nil)

--- a/Sources/appdecrypt/ConsoleIO.swift
+++ b/Sources/appdecrypt/ConsoleIO.swift
@@ -46,6 +46,7 @@ class ConsoleIO {
         
         OPTIONS:
           -h, --help              Show help information.
+          --ignore-ios-check      Decrypt the app anyway, even if M1 can't run it.
         """)
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: NSNotification.Name("stop"), object: nil)

--- a/Sources/appdecrypt/dump.swift
+++ b/Sources/appdecrypt/dump.swift
@@ -78,7 +78,7 @@ class Dump {
                     if let output = String(data: data, encoding: String.Encoding.utf8) {
                         if output.contains("LC_VERSION_MIN_IPHONEOS") || output.contains("platform 2") {
                             if !ignoreIOSOnlyCheck {
-                                consoleIO.writeMessage("This app not support dump on M1 Mac. Because machO PLATFORM is IOS ! Ignore this by adding argument --ignore-ios-check")
+                                consoleIO.writeMessage("This app can't run on Mac M1 ! However, you can decrypt it anyway by adding argument --ignore-ios-check")
                                 do { try fileManager.removeItem(atPath: targetUrl) } catch {}
                                 exit(-10)
                             } else {

--- a/Sources/appdecrypt/dump.swift
+++ b/Sources/appdecrypt/dump.swift
@@ -34,6 +34,10 @@ class Dump {
         if targetUrl.hasSuffix("/") {
             targetUrl.removeLast()
         }
+        
+        var ignoreIOSOnlyCheck = false
+        ignoreIOSOnlyCheck = CommandLine.arguments.contains("--ignore-ios-check")
+        
         #if os(iOS)
         if !targetUrl.hasSuffix("/Payload") {
             targetUrl += "/Payload"
@@ -73,9 +77,13 @@ class Dump {
                     let data = pipe.fileHandleForReading.readDataToEndOfFile()
                     if let output = String(data: data, encoding: String.Encoding.utf8) {
                         if output.contains("LC_VERSION_MIN_IPHONEOS") || output.contains("platform 2") {
-                            consoleIO.writeMessage("This app not support dump on M1 Mac. Because machO PLATFORM is IOS!")
-                            do { try fileManager.removeItem(atPath: targetUrl) } catch {}
-                            exit(-10)
+                            if !ignoreIOSOnlyCheck {
+                                consoleIO.writeMessage("This app not support dump on M1 Mac. Because machO PLATFORM is IOS ! Ignore this by adding argument --ignore-ios-check")
+                                do { try fileManager.removeItem(atPath: targetUrl) } catch {}
+                                exit(-10)
+                            } else {
+                                consoleIO.writeMessage("Warning ! The app is will not run on M1 Mac. Decrypting it anyway.")
+                            }
                         }
                     }
                     #endif

--- a/Sources/appdecrypt/main.swift
+++ b/Sources/appdecrypt/main.swift
@@ -8,7 +8,7 @@
 import Foundation
 import MachO
 
-let version = "2.2"
+let version = "2.3"
 
 var running = true
 


### PR DESCRIPTION
Some people here https://github.com/paradiseduo/appdecrypt/issues/14 complained that the README isn't clear enough and doesn't mention the fact that some apps, even after decryption, won't be runnable, so I added that.

I also added an argument `--ignore-ios-check` for people like me who wants to decrypt the app, even if it is not made to run on the Mac.