### PR TITLE
fix: scp arg splitting & hardened iOS build script

### DIFF
--- a/build-iOS.sh
+++ b/build-iOS.sh
@@ -3,12 +3,14 @@
 set -e
 
 NAME=appdecrypt
+BUILD_OUTPUT=".build/release/appdecrypt"
+OUTPUT="./appdecrypt"
 SDK_VERSION=11.0
 
 function build() {
   START=$(date +%s)
 
-  swift build --product $NAME \
+  swift build --product "$NAME" \
     -c release \
     -Xswiftc "-sdk" \
     -Xswiftc "$(xcrun --sdk iphoneos --show-sdk-path)" \
@@ -33,11 +35,14 @@ function main() {
 
 main
 
-mv .build/release/appdecrypt .
-chmod +x appdecrypt
+if [ -L "$OUTPUT" ]; then
+  rm -f "$OUTPUT"
+fi
+cp "$BUILD_OUTPUT" "$OUTPUT"
+chmod 0755 "$OUTPUT"
 ldid -Sglobal.xml appdecrypt
 
 # if ip is provided, send to the device in one go
 if [ -n "$1" ]; then
-  scp appdecrypt mobile@$1:/var/mobile/Documents/appdecrypt
+  scp -- appdecrypt "mobile@$1:/var/mobile/Documents/appdecrypt"
 fi


### PR DESCRIPTION
This PR protects the `scp` transfer from argument splitting. It also hardens `build-iOS.sh` with symlink-safe output handling.